### PR TITLE
All rspec tests passing, show page routes set up correctly

### DIFF
--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -1,5 +1,5 @@
 class AuthorsController < ApplicationController
   def show
-    @author = Author.first
+    @author = Author.find(params[:id])
   end
 end

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,17 +1,17 @@
 class BooksController < ApplicationController
   def index
     if params[:sort] == 'pages'
-      @books = Book.sort_by_pages(order)
+      @books = Book.sort_by_pages(params[:order])
     elsif params[:sort] == 'pages_desc'
-      @books = Book.sort_by_pages(order)
+      @books = Book.sort_by_pages(params[:order])
     elsif params[:sort] == 'rating'
-      @books = Book.sort_by_rating(order)
+      @books = Book.sort_by_rating(params[:order])
     elsif params[:sort] == 'rating_desc'
-      @books = Book.sort_by_rating(order)
+      @books = Book.sort_by_rating(params[:order])
     elsif params[:sort] == 'review_number'
-      @books = Book.sort_by_review_number(order)
+      @books = Book.sort_by_review_number(params[:order])
     elsif params[:sort] == 'review_number_desc'
-      @books = Book.sort_by_review_number(order)
+      @books = Book.sort_by_review_number(params[:order])
     else
       @books = Book.all
     end
@@ -21,7 +21,7 @@ class BooksController < ApplicationController
   end
 
   def show
-    @book = Book.first
+    @book = Book.find(params[:id])
   end
 
   def destroy

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -1,6 +1,6 @@
 class ReviewsController < ApplicationController
   def destroy
     Review.find(params[:id]).destroy
-    redirect_to user_path
+    redirect_to user_path(params[:user_id])
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   def show
-    @user = User.first
+    @user = User.find(params[:id])
     if params[:sort] == 'oldest'
       @reviews = @user.sort_by_oldest
     elsif params[:sort] == 'newest'

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -34,14 +34,14 @@
     <div><p>Sort page by:</p></div>
     <div class="sorting-links">
       <div class="links-row-1">
-        <%= link_to('Pages (Ascending)', books_path(sort: :pages)) %>
-        <%= link_to('Pages (Descending)', books_path(sort: :pages_desc)) %>
-        <%= link_to('Rating (Ascending)', books_path(sort: :rating)) %>
+        <%= link_to('Pages (Ascending)', books_path(sort: :pages, order: :asc)) %>
+        <%= link_to('Pages (Descending)', books_path(sort: :pages_desc, order: :desc)) %>
+        <%= link_to('Rating (Ascending)', books_path(sort: :rating, order: :asc)) %>
       </div>
       <div class = "links-row-2">
-        <%= link_to('Rating (Descending)', books_path(sort: :rating_desc)) %>
-        <%= link_to('Reviews (Ascending)', books_path(sort: :review_number)) %>
-        <%= link_to('Reviews (Descending)', books_path(sort: :review_number_desc)) %>
+        <%= link_to('Rating (Descending)', books_path(sort: :rating_desc, order: :desc)) %>
+        <%= link_to('Reviews (Ascending)', books_path(sort: :review_number, order: :asc)) %>
+        <%= link_to('Reviews (Descending)', books_path(sort: :review_number_desc, order: :desc)) %>
       </div>
     </div>
   </div>
@@ -55,7 +55,7 @@
           <p>Publication Year: <%= book.year %></p>
         </div>
         <div>
-          <p>Average Score: <%= book.reviews.average(:rating) %> </p>
+          <p>Average Score: <%= book.average_rating %> </p>
           <p>Number of Reviews: <%= book.reviews.count %> </p>
         </div>
       </div>

--- a/spec/features/book_index_spec.rb
+++ b/spec/features/book_index_spec.rb
@@ -3,31 +3,30 @@ require 'rails_helper'
 RSpec.describe 'when visitor visits book index page', type: :feature do
   before :each do
     @author_1 = Author.create(name: "Gloria Stiehl")
-    @book_1 = Book.create(title: "new book", pages:20, year: 2019, authors: [@author_1])
+    @book_1 = Book.create(title: "new book", pages:10, year: 2019, authors: [@author_1])
     @user_1 = User.create(name: "Joe")
     @user_3 = User.create(name: "Josh")
     @user_2 = User.create(name: "Jane")
-    @review_1 = @book_1.reviews.create(review_title: "terrible", rating: 3, text: "terrible and boring, too long.", user: @user_1)
-    @review_2 = @book_1.reviews.create(review_title: "LOL", rating: 5, text: "very fun; lots of laughs", user: @user_2)
-    @review_3 = @book_1.reviews.create(review_title: "stuff", rating: 4, text: "all the stuff", user: @user_3)
+    @review_1 = @book_1.reviews.create(review_title: "LOL", rating: 5, text: "very fun; lots of laughs", user: @user_2)
+    @review_2 = @book_1.reviews.create(review_title: "stuff", rating: 4, text: "all the stuff", user: @user_3)
 
     @author_2 = Author.create(name: "Gloria Estonia")
-    @book_2 = Book.create(title: "The only book you need", pages:20, year: 2019, authors: [@author_2])
-    @review_4 = @book_2.reviews.create(review_title: "ok", rating: 5, text: "not my thing", user: @user_2)
-    @review_5 = @book_2.reviews.create(review_title: "fun", rating: 5, text: "good times, good read", user: @user_1)
-    @review_6 = @book_2.reviews.create(review_title: "interesting", rating: 5, text: "when does the second book come out???", user: @user_1)
+    @book_2 = Book.create(title: "The only book you need", pages:20, year: 2019, authors: [@author_1, @author_2])
+    @review_3 = @book_2.reviews.create(review_title: "ok", rating: 5, text: "not my thing", user: @user_2)
+    @review_4 = @book_2.reviews.create(review_title: "fun", rating: 5, text: "good times, good read", user: @user_1)
+    @review_5 = @book_2.reviews.create(review_title: "interesting", rating: 5, text: "when does the second book come out???", user: @user_1)
 
     @author_3 = Author.create(name: "John Stone")
-    @book_3 = Book.create(title: "Intergalactic Voyage", pages:20, year: 2019, authors: [@author_3])
+    @book_3 = Book.create(title: "Intergalactic Voyage", pages:30, year: 2019, authors: [@author_3])
+    @review_6 = @book_3.reviews.create(review_title: "terrible", rating: 3, text: "terrible and boring, too long.", user: @user_1)
     @review_7 = @book_3.reviews.create(review_title: "my review", rating: 1, text: "text", user: @user_1)
     @review_8 = @book_3.reviews.create(review_title: "meh", rating: 3, text: "some text", user: @user_1)
     @review_9 = @book_3.reviews.create(review_title: "leaves something to be desired", rating: 2, text: "more text and stuff", user: @user_1)
+    @review_10 = @book_3.reviews.create(review_title: "a", rating: 1, text: "a", user: @user_1)
 
     @author_3 = Author.create(name: "John Stone")
-    @book_4 = Book.create(title: "The first Voyage", pages:20, year: 2019, authors: [@author_3])
-    @review_10 = @book_4.reviews.create(review_title: "a", rating: 1, text: "a", user: @user_1)
+    @book_4 = Book.create(title: "The first Voyage", pages:40, year: 2019, authors: [@author_3])
     @review_11 = @book_4.reviews.create(review_title: "b", rating: 1, text: "b", user: @user_1)
-    @review_12 = @book_4.reviews.create(review_title: "c", rating: 1, text: "c", user: @user_1)
   end
   it 'can see all titles and attributes of each book in the database' do
     #User Story 6
@@ -54,13 +53,13 @@ RSpec.describe 'when visitor visits book index page', type: :feature do
     visit books_path
 
     within(class: "book-#{@book_1.id}") do
-      expect(page).to have_content('Average Score: 4')
-      expect(page).to have_content('Number of Reviews: 2')
+      expect(page).to have_content("Average Score: #{@book_1.average_rating}")
+      expect(page).to have_content("Number of Reviews: #{@book_1.reviews.count}")
     end
 
     within(class: "book-#{@book_2.id}") do
-      expect(page).to have_content('Average Score: 5')
-      expect(page).to have_content('Number of Reviews: 1')
+      expect(page).to have_content("Average Score: #{@book_2.average_rating}")
+      expect(page).to have_content("Number of Reviews: #{@book_2.reviews.count}")
     end
   end
 
@@ -68,35 +67,34 @@ RSpec.describe 'when visitor visits book index page', type: :feature do
     #User Story 8
     visit books_path
     click_link('Pages (Ascending)')
-    expect(page.all('.book-title')[0]).to have_content('Good Omens')
-    expect(page.all('.book-title')[1]).to have_content('Harry Potter and the Sorcerer\'s Stone')
-    expect(page.all('.book-title')[2]).to have_content('House of Leaves')
+    expect(page.all('.book-title')[0]).to have_content("#{@book_1.title}")
+    expect(page.all('.book-title')[1]).to have_content("#{@book_2.title}")
+    expect(page.all('.book-title')[2]).to have_content("#{@book_3.title}")
 
     click_link('Pages (Descending)')
-    expect(page.all('.book-title')[0]).to have_content('House of Leaves')
-    expect(page.all('.book-title')[1]).to have_content('Harry Potter and the Sorcerer\'s Stone')
-    expect(page.all('.book-title')[2]).to have_content('Good Omens')
+    expect(page.all('.book-title')[0]).to have_content("#{@book_4.title}")
+    expect(page.all('.book-title')[1]).to have_content("#{@book_3.title}")
+    expect(page.all('.book-title')[2]).to have_content("#{@book_2.title}")
 
-    # Need to add default value to average rating
-    # click_link('Rating (Ascending)')
-    # expect(page.all('.book-title')[0]).to have_content('Harry Potter and the Sorcerer\'s Stone')
-    # expect(page.all('.book-title')[1]).to have_content('House of Leaves')
-    # expect(page.all('.book-title')[2]).to have_content('Good Omens')
-    #
-    # click_link('Rating (Descending)')
-    # expect(page.all('.book-title')[0]).to have_content('Good Omens')
-    # expect(page.all('.book-title')[1]).to have_content('House of Leaves')
-    # expect(page.all('.book-title')[2]).to have_content('Harry Potter and the Sorcerer\'s Stone')
+    click_link('Rating (Ascending)')
+    expect(page.all('.book-title')[0]).to have_content("#{@book_4.title}")
+    expect(page.all('.book-title')[1]).to have_content("#{@book_3.title}")
+    expect(page.all('.book-title')[2]).to have_content("#{@book_1.title}")
+
+    click_link('Rating (Descending)')
+    expect(page.all('.book-title')[0]).to have_content("#{@book_2.title}")
+    expect(page.all('.book-title')[1]).to have_content("#{@book_1.title}")
+    expect(page.all('.book-title')[2]).to have_content("#{@book_3.title}")
 
     click_link('Reviews (Ascending)')
-    expect(page.all('.book-title')[0]).to have_content('Harry Potter and the Sorcerer\'s Stone')
-    expect(page.all('.book-title')[1]).to have_content('Good Omens')
-    expect(page.all('.book-title')[2]).to have_content('House of Leaves')
+    expect(page.all('.book-title')[0]).to have_content("#{@book_4.title}")
+    expect(page.all('.book-title')[1]).to have_content("#{@book_1.title}")
+    expect(page.all('.book-title')[2]).to have_content("#{@book_2.title}")
 
     click_link('Reviews (Descending)')
-    expect(page.all('.book-title')[0]).to have_content('House of Leaves')
-    expect(page.all('.book-title')[1]).to have_content('Good Omens')
-    expect(page.all('.book-title')[2]).to have_content('Harry Potter and the Sorcerer\'s Stone')
+    expect(page.all('.book-title')[0]).to have_content("#{@book_3.title}")
+    expect(page.all('.book-title')[1]).to have_content("#{@book_2.title}")
+    expect(page.all('.book-title')[2]).to have_content("#{@book_1.title}")
   end
 
   it 'sees a navigation bar' do
@@ -141,7 +139,7 @@ RSpec.describe 'when visitor visits book index page', type: :feature do
       fill_in 'Pages', with: 150
       fill_in 'Year', with: 1990
       click_on 'Submit'
-      save_and_open_page
+
       expect(page).to have_current_path(books_path)
       expect(page).to have_content('Title 1')
       expect(page).to have_content("Author(s): Author 1, Author 2")

--- a/spec/features/book_show_spec.rb
+++ b/spec/features/book_show_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'when visitor visits a book\'s show page', type: :feature do
   it 'has an option to delete each book' do
     visit book_path(@book_1.id)
     click_link('Delete Book')
-    save_and_open_page
+    
     expect(current_path).to eq(books_path)
     expect(page).to_not have_content("#{@book_1.title}")
     expect(page).to_not have_content("Rating: 3.0 / 5")


### PR DESCRIPTION
Hi Jennica, I made this branch to fix all of the hardcoded tests in the book index spec that were failing before. Here are the changes I made:

- I realized that the show page routes in the controllers were not going to the right place because I had them set up to always go to the first id instead of passing in an id in the params hash. I fixed it so the pages link to the correct id now.
- I changed the index method in the books controller to accept the argument for sorting order from the params hash
- I changed the route in the reviews controller to go to back to the corresponding user’s show page after deleting a review
- I changed most of the index tests to accept more dynamic values

Take a look at the files and merge it if you think it's all good!