### PR TITLE
Changed worst books by rating method to not use a left outer joins

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -49,6 +49,10 @@ class Book < ApplicationRecord
   end
 
   def self.bottom_by_rating
-    sort_by_rating(:asc).first(3)
+    Book.select('books.*, coalesce(avg(reviews.rating), 0) as avg_rating')
+        .joins(:reviews)
+        .group('books.id')
+        .order("avg_rating asc")
+        .first(3)
   end
 end


### PR DESCRIPTION
Hey Jennica, this is just one tiny change that I found while testing out our app this morning. I realized our statistics area on our index page for worst rated books was displaying info for books without ratings because we were calling the left outer joins method to grab the worst books. I only had to change one line to fix it and all our tests are still passing.